### PR TITLE
Feature/pinned archive post

### DIFF
--- a/_data/language.yml
+++ b/_data/language.yml
@@ -57,3 +57,4 @@ about_csis_heading: The Center for Strategic and International Studies (CSIS)
 about_the_people_heading: The People
 about_the_credits_heading: The Credits
 about_related_links_heading: Related Links
+featured_heading: Featured

--- a/_includes/post-list.html
+++ b/_includes/post-list.html
@@ -1,20 +1,20 @@
 <article class="post-list" role="article" data-content-type="{{ post.content_type }}">
-  {% if post.image.size > 0 and post.image != site.logo %}<a href="{{ post.url | relative_url }}" class="post-list-img"><img src="{{ post.image | relative_url }}" alt="{{ post.title | escape }}" title="{{ post.title | escape }}" /></a>{% endif %}
-  <header class="post-list-header" role="article header">
-    {% assign content_type = site.data.content_types | where: "type", post.content_type %}
-    <h2 class="post-list-title"><a href="{{ post.url | relative_url }}">
+	{% if post.image.size > 0 and post.image != site.logo %}<a href="{{ post.url | relative_url }}" class="post-list-img"><img src="{{ post.image | relative_url }}" alt="{{ post.title | escape }}" title="{{ post.title | escape }}" /></a>{% endif %}
+	<header class="post-list-header" role="article header">
+		{% assign content_type = site.data.content_types | where: "type", post.content_type %}
+		<h2 class="post-list-title"><a href="{{ post.url | relative_url }}">
       {% if post.content_type and content_type[0].icon %}<i class="{{ content_type[0].icon }}"></i>{% endif %}{{ post.title | escape }}
     </a></h2>
-    <span class="post-meta">{{ post.date | date: site.date_format }}
+		<span class="post-meta">{{ post.date | date: site.date_format }}
       {% if post.collection == 'podcast' %}
         &mdash; {{ post.episode_num | prepend: 'Episode #' }}
       {% endif %}
     </span>
-  </header>
-  <main class="post-list-content" role="article content">
-    {% if post.collection == 'podcast' and (page.layout == 'home' or forloop.first) %}
-      {% include audio-player.html soundcloud_url=post.soundcloud_url transcript_url=post.transcript_url %}
-    {% endif %}
-    <p>{{ post.excerpt }}</p>
-  </main>
+	</header>
+	<main class="post-list-content" role="article content">
+		{% if post.collection == 'podcast' and (page.layout == 'home' or forloop.first) %}
+		{% include audio-player.html soundcloud_url=post.soundcloud_url transcript_url=post.transcript_url %}
+		{% endif %}
+		<p>{{ post.excerpt }}</p>
+	</main>
 </article>

--- a/_includes/post-list.html
+++ b/_includes/post-list.html
@@ -1,9 +1,9 @@
-{% if post.featured_in_archive == true %}
-	<span class="post-list-featured">{{ site.data.language.featured_heading }}</span>
-{% endif %}
 <article class="post-list" role="article" data-content-type="{{ post.content_type }}">
 	{% if post.image.size > 0 and post.image != site.logo %}<a href="{{ post.url | relative_url }}" class="post-list-img"><img src="{{ post.image | relative_url }}" alt="{{ post.title | escape }}" title="{{ post.title | escape }}" /></a>{% endif %}
 	<header class="post-list-header" role="article header">
+		{% if post.featured_in_archive == true %}
+			<span class="post-list-featured">{{ site.data.language.featured_heading }}</span>
+		{% endif %}
 		{% assign content_type = site.data.content_types | where: "type", post.content_type %}
 		<h2 class="post-list-title"><a href="{{ post.url | relative_url }}">
       {% if post.content_type and content_type[0].icon %}<i class="{{ content_type[0].icon }}"></i>{% endif %}{{ post.title | escape }}

--- a/_includes/post-list.html
+++ b/_includes/post-list.html
@@ -1,3 +1,6 @@
+{% if post.featured_in_archive == true %}
+	<span class="post-list-featured">{{ site.data.language.featured_heading }}</span>
+{% endif %}
 <article class="post-list" role="article" data-content-type="{{ post.content_type }}">
 	{% if post.image.size > 0 and post.image != site.logo %}<a href="{{ post.url | relative_url }}" class="post-list-img"><img src="{{ post.image | relative_url }}" alt="{{ post.title | escape }}" title="{{ post.title | escape }}" /></a>{% endif %}
 	<header class="post-list-header" role="article header">

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -17,7 +17,7 @@ layout: default
     {% endif %}
     {% for post in posts %}
 			{% if post.featured_in_archive == true %}
-				{% post-list.html %}
+				{% include post-list.html %}
 			{% endif %}
 		{% endfor %}
 		{% for post in posts %}

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -17,7 +17,7 @@ layout: default
     {% endif %}
     {% for post in posts %}
 			{% if post.featured_in_archive == true %}
-				{% include post-list.html %}
+				{% post-list.html %}
 			{% endif %}
 		{% endfor %}
 		{% for post in posts %}

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -15,7 +15,16 @@ layout: default
     {% else %}
       {% assign posts = site.posts | sort: 'date' | reverse %}
     {% endif %}
-    {% for post in posts %}{% include post-list.html %}{% endfor %}
+    {% for post in posts %}
+			{% if post.featured_in_archive == true %}
+				{% post-list.html %}
+			{% endif %}
+		{% endfor %}
+		{% for post in posts %}
+			{% unless post.featured_in_archive == true %}
+				{% include post-list.html %}
+			{% endunless %}
+		{% endfor %}
 	</div>
   {% include sidebar.html %}
 	{% include page-footer.html %}

--- a/_posts/2017-10-19-50-states-trade.md
+++ b/_posts/2017-10-19-50-states-trade.md
@@ -20,7 +20,6 @@ authors: []
 image: "/uploads/statetradeCropped.gif"
 image_caption: ''
 image_credit: CSIS iDeas Lab
-featured_in_archive: true
 
 ---
 <iframe class="interactive-iframe js-iframeResizeEnabled" width="96%" height="852px" scrolling="no" frameborder="no" src="https://csis-ilab.github.io/tradeguys-viz/tariff-impact-states/dist/"></iframe>

--- a/_posts/2017-10-19-50-states-trade.md
+++ b/_posts/2017-10-19-50-states-trade.md
@@ -20,7 +20,6 @@ authors: []
 image: "/uploads/statetradeCropped.gif"
 image_caption: ''
 image_credit: CSIS iDeas Lab
-featured: true
 featured_in_archive: true
 
 ---

--- a/_posts/2018-08-06-whither-or-wither-wto.md
+++ b/_posts/2018-08-06-whither-or-wither-wto.md
@@ -16,8 +16,7 @@ show_image_on_single_post: true
 excerpt: WTO negotiations have all but ground to a halt while countries flout their
   obligations. U.S. tariffs on steel, aluminum, and imports from China have put additional
   pressure on the WTO’s rules and relevancy.
-
 ---
-The World Trade Organization is under attack and its future is in question. Negotiations have all but ground to a halt while countries flout their obligations. U.S. tariffs on steel, aluminum, and imports from China have put additional pressure on the WTO’s rules and relevancy. 
+The World Trade Organization is under attack and its future is in question. Negotiations have all but ground to a halt while countries flout their obligations. U.S. tariffs on steel, aluminum, and imports from China have put additional pressure on the WTO’s rules and relevancy.
 
 So what should be done? The system needs to be defended. And to do that, the U.S. must reassume its leadership role within the organization.

--- a/_posts/2018-09-04-so-what-just-happened.md
+++ b/_posts/2018-09-04-so-what-just-happened.md
@@ -17,6 +17,7 @@ keywords: []
 image: "/uploads/180904_U.S_Canada-compressor.jpg"
 image_caption: ''
 image_credit: LARS HAGBERG/AFP/Getty Images
+featured_in_archive: true
 
 ---
 Last Friday, my usual writing day, I did my column on a nice safe topic, protectionism, and then planned to go home. As usual, however, reality got in the way; this time in the form of Canada. So protectionism will wait for another day—it's definitely not going anywhere—and instead, I will spend a few minutes on what happened last week. Of course, you know what happened—the United States and Canada did not reach agreement; the administration notified Congress anyway of its intent to sign an agreement, at least with Mexico and perhaps with Canada later; the parties said surprisingly nice things about each other (except for our president who was rude as usual) and agreed to meet again this week. So, what does it all mean?  

--- a/_posts/2018-09-04-so-what-just-happened.md
+++ b/_posts/2018-09-04-so-what-just-happened.md
@@ -17,7 +17,6 @@ keywords: []
 image: "/uploads/180904_U.S_Canada-compressor.jpg"
 image_caption: ''
 image_credit: LARS HAGBERG/AFP/Getty Images
-featured_in_archive: true
 
 ---
 Last Friday, my usual writing day, I did my column on a nice safe topic, protectionism, and then planned to go home. As usual, however, reality got in the way; this time in the form of Canada. So protectionism will wait for another day—it's definitely not going anywhere—and instead, I will spend a few minutes on what happened last week. Of course, you know what happened—the United States and Canada did not reach agreement; the administration notified Congress anyway of its intent to sign an agreement, at least with Mexico and perhaps with Canada later; the parties said surprisingly nice things about each other (except for our president who was rude as usual) and agreed to meet again this week. So, what does it all mean?  

--- a/_posts/2018-09-07-steel-and-aluminum-tariffs-a-push-and-pull-between-the-president-and-congress.md
+++ b/_posts/2018-09-07-steel-and-aluminum-tariffs-a-push-and-pull-between-the-president-and-congress.md
@@ -22,7 +22,6 @@ keywords:
 image: "/uploads/180906_steel-compressor.jpg"
 image_caption: ''
 image_credit: JULIO CESAR AGUILAR/AFP/Getty Images
-featured_in_archive: true
 
 ---
 President Trump’s decision to impose steel and aluminum tariffs and his threat to put tariffs on automobiles and parts [under Section 232 of the Trade Expansion Act of 1962 ](https://www.whitehouse.gov/presidential-actions/presidential-proclamation-adjusting-imports-steel-united-states/)have generated anxiety on Capitol Hill. Lawmakers have expressed concern about the economic impact of the tariffs as well as the legal foundation for them. The tariffs have harmed U.S. companies that rely on foreign steel and aluminum products not made in the United States. The metal tariffs have also led to retaliation from major U.S. trading partners. Canada has put tariffs on over $12 billion of U.S. imports. Mexico, China, and the European Union have imposed their own tariffs on roughly $3 billion of U.S. imports each. To escape the tariffs, Argentina, Brazil, and South Korea have agreed to quotas to cap their steel exports to the United States at a level below their recent annual export levels. Argentina has also agreed to an aluminum export quota. Quota arrangements with Canada and Mexico could be announced alongside a final NAFTA deal, which could come by the end of the month.

--- a/_posts/2018-09-07-steel-and-aluminum-tariffs-a-push-and-pull-between-the-president-and-congress.md
+++ b/_posts/2018-09-07-steel-and-aluminum-tariffs-a-push-and-pull-between-the-president-and-congress.md
@@ -22,6 +22,7 @@ keywords:
 image: "/uploads/180906_steel-compressor.jpg"
 image_caption: ''
 image_credit: JULIO CESAR AGUILAR/AFP/Getty Images
+featured_in_archive: true
 
 ---
 President Trump’s decision to impose steel and aluminum tariffs and his threat to put tariffs on automobiles and parts [under Section 232 of the Trade Expansion Act of 1962 ](https://www.whitehouse.gov/presidential-actions/presidential-proclamation-adjusting-imports-steel-united-states/)have generated anxiety on Capitol Hill. Lawmakers have expressed concern about the economic impact of the tariffs as well as the legal foundation for them. The tariffs have harmed U.S. companies that rely on foreign steel and aluminum products not made in the United States. The metal tariffs have also led to retaliation from major U.S. trading partners. Canada has put tariffs on over $12 billion of U.S. imports. Mexico, China, and the European Union have imposed their own tariffs on roughly $3 billion of U.S. imports each. To escape the tariffs, Argentina, Brazil, and South Korea have agreed to quotas to cap their steel exports to the United States at a level below their recent annual export levels. Argentina has also agreed to an aluminum export quota. Quota arrangements with Canada and Mexico could be announced alongside a final NAFTA deal, which could come by the end of the month.

--- a/_posts/2018-10-23-wto-reform-the-beginning-of-the-end-or-the-end-of-the-beginning.md
+++ b/_posts/2018-10-23-wto-reform-the-beginning-of-the-end-or-the-end-of-the-beginning.md
@@ -21,5 +21,7 @@ image: "/uploads/181023_WTO_0-compressor.jpg"
 image_caption: ''
 image_credit: FABRICE COFFRINI/AFP/Getty Images
 
+
+
 ---
 Members of the World Trade Organization (WTO) have become increasingly frustrated with all three of its main functions: monitoring member states’ trade policies, providing a forum to negotiate new trade agreements, and arbitrating trade disputes. In recent months, this has triggered an effort to reform the WTO—what U.S. ambassador to the WTO Dennis Shea [termed](https://www.csis.org/events/wto-looking-forward) “the Autumn of WTO reform.” On October 24-25, Canada will host a meeting of 12 other trade ministers, including those from Brazil, the European Union, and Japan, to discuss possible reforms to the WTO. The United States and China have not been invited to the meeting in Ottawa but are expected to join the process “[at a later date](https://www.bbc.com/news/world-us-canada-45674264)” to update the WTO’s policies and processes to better suit twenty-first-century trade challenges.

--- a/_posts/2018-10-23-wto-reform-the-beginning-of-the-end-or-the-end-of-the-beginning.md
+++ b/_posts/2018-10-23-wto-reform-the-beginning-of-the-end-or-the-end-of-the-beginning.md
@@ -21,7 +21,5 @@ image: "/uploads/181023_WTO_0-compressor.jpg"
 image_caption: ''
 image_credit: FABRICE COFFRINI/AFP/Getty Images
 
-
-
 ---
 Members of the World Trade Organization (WTO) have become increasingly frustrated with all three of its main functions: monitoring member states’ trade policies, providing a forum to negotiate new trade agreements, and arbitrating trade disputes. In recent months, this has triggered an effort to reform the WTO—what U.S. ambassador to the WTO Dennis Shea [termed](https://www.csis.org/events/wto-looking-forward) “the Autumn of WTO reform.” On October 24-25, Canada will host a meeting of 12 other trade ministers, including those from Brazil, the European Union, and Japan, to discuss possible reforms to the WTO. The United States and China have not been invited to the meeting in Ottawa but are expected to join the process “[at a later date](https://www.bbc.com/news/world-us-canada-45674264)” to update the WTO’s policies and processes to better suit twenty-first-century trade challenges.

--- a/assets/_sass/base/_typography.scss
+++ b/assets/_sass/base/_typography.scss
@@ -169,6 +169,14 @@ textarea {
   }
 }
 
+%featured-post {
+  font-family: $font_inconsolata;
+  @include fontSize(13px);
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 1.3px;
+}
+
 /*================================
 =            Headings            =
 ================================*/

--- a/assets/_sass/components/_post-list.scss
+++ b/assets/_sass/components/_post-list.scss
@@ -69,6 +69,10 @@
     @extend %archive-feature-post-title;
   }
 
+  &-featured {
+    @extend %featured-post;
+  }
+
   &-content {
     grid-row: 2;
     grid-column: 1 / 3;
@@ -115,4 +119,3 @@
   }
 
 }
-


### PR DESCRIPTION
- User can toggle `featured_in_archive` to true (new field in Forestry.io), which pins the post to the top of the list (edited archive include)
- Should these pinned posts have something noting that their pinned? Like an icon or small 'pinned' text?